### PR TITLE
Slight Cache API rework

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -1,4 +1,6 @@
 import redis
+from discord import Guild as DiscordGuild
+from discord import Member as DiscordMember
 
 from app.utilities import logger
 from .config import config
@@ -14,3 +16,28 @@ def check():
         logger.critical(e)
         logger.critical("Redis is not running. Please start it.")
         exit(1)
+
+def format_key(key, guild:DiscordGuild=None, member:DiscordMember=None):
+    if guild != None:
+        key += ":g!" + str(guild.id)
+
+    if member != None:
+        key += ":u!" + str(member.id)
+
+    return key
+
+def cache_get(key, default_value, guild:DiscordGuild=None, member:DiscordMember=None, should_add_value_if_missing:bool=True):
+    formatted_key = format_key(key, guild, member)
+    value = cache.get(formatted_key)
+
+    if not value:
+        value = default_value
+
+        if should_add_value_if_missing:
+            cache.set(formatted_key, value)
+
+    return value
+
+def cache_set(key, value, guild:DiscordGuild=None, member:DiscordMember=None):
+    formatted_key = format_key(key, guild, member)
+    cache.set(formatted_key, value)

--- a/app/cache.py
+++ b/app/cache.py
@@ -1,6 +1,8 @@
 import redis
 from discord import Guild as DiscordGuild
 from discord import Member as DiscordMember
+from discord import User as DiscordUser
+from typing import Union
 
 from app.utilities import logger
 from .config import config
@@ -17,27 +19,27 @@ def check():
         logger.critical("Redis is not running. Please start it.")
         exit(1)
 
-def format_key(key, guild:DiscordGuild=None, member:DiscordMember=None):
+def format_key(key:str, guild:DiscordGuild=None, user:Union[DiscordMember,DiscordUser]=None):
     if guild != None:
         key += ":g!" + str(guild.id)
 
-    if member != None:
-        key += ":u!" + str(member.id)
+    if user != None:
+        key += ":u!" + str(user.id)
 
     return key
 
-def cache_get(key, default_value, guild:DiscordGuild=None, member:DiscordMember=None, should_add_value_if_missing:bool=True):
-    formatted_key = format_key(key, guild, member)
+def cache_get(key:str, default_value=None, guild:DiscordGuild=None, user:Union[DiscordMember,DiscordUser]=None, should_add_value_if_missing:bool=True):
+    formatted_key = format_key(key, guild, user)
     value = cache.get(formatted_key)
 
-    if not value:
+    if not value and default_value != None:
         value = default_value
 
         if should_add_value_if_missing:
             cache.set(formatted_key, value)
-
+            
     return value
 
-def cache_set(key, value, guild:DiscordGuild=None, member:DiscordMember=None):
-    formatted_key = format_key(key, guild, member)
+def cache_set(key:str, value, guild:DiscordGuild=None, user:Union[DiscordMember,DiscordUser]=None):
+    formatted_key = format_key(key, guild, user)
     cache.set(formatted_key, value)

--- a/app/client.py
+++ b/app/client.py
@@ -35,13 +35,12 @@ class PhoneWave(bridge.Bot):
         if message.guild is None:
             return config.BOT_PREFIX
 
-        prefix = cache_get("prefix", config.BOT_PREFIX, message.guild)
+        prefix = cache_get("prefix", guild=message.guild)
         if not prefix:
             logger.debug(f"Querying guild prefix for {message.guild.name}... & caching it")
             guild = Guild.objects(guild_id=message.guild.id).first()
             prefix = guild.prefix if guild and guild.prefix else config.BOT_PREFIX
             cache_set("prefix", prefix, message.guild)
-
         return prefix
 
     def run(self):

--- a/app/client.py
+++ b/app/client.py
@@ -2,7 +2,8 @@ import discord
 from discord.ext import bridge
 from discord.message import Message
 
-from app import database, cache
+from app import database
+from app.cache import cache_get, cache_set, check as cache_check
 from app.config import config
 from app.database.models import Guild
 from app.exceptions.bad_config import BadConfig
@@ -23,7 +24,7 @@ class PhoneWave(bridge.Bot):
 
         # initialize MongoDB and Redis connections
         database.init()
-        cache.check()
+        cache_check()
 
         # autoload the commands, events & the modules
         handlers.load_modules(self)
@@ -34,13 +35,12 @@ class PhoneWave(bridge.Bot):
         if message.guild is None:
             return config.BOT_PREFIX
 
-        cache_key = 'prefix:' + str(message.guild.id)
-        prefix = cache.cache.get(cache_key)
+        prefix = cache_get("prefix", config.BOT_PREFIX, message.guild)
         if not prefix:
             logger.debug(f"Querying guild prefix for {message.guild.name}... & caching it")
             guild = Guild.objects(guild_id=message.guild.id).first()
             prefix = guild.prefix if guild and guild.prefix else config.BOT_PREFIX
-            cache.cache.set(cache_key, prefix)
+            cache_set("prefix", prefix, message.guild)
 
         return prefix
 


### PR DESCRIPTION
+ Added format_key(key, guild, user) to cache.py: used to format a key in a way to work for Redis
+ Added cache_get(key, default_value, guild, user, should_add_value_if_missing) to cache.py: auto-formats the key with the given information. If given a default_value, will return that on None return. If default_value should_add_value_if_missing are set and no value is found, auto-adds the key,value pair to the cache
+ Added cache_set(key, value, guild, user) to cache.py: auto-formats the key with the given information, and sets the key,value pair in the cache
+ Updated client.py to reflect these new changes
+ Also changed the cache import in client.py to only grab the required functions and to alias cache.check to cache_check