### PR TITLE
Remove testcord from dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ redis = "*"
 black = "*"
 structlog = "*"
 python-dotenv = "*"
-testcord = {ref = "feature/improve-coverage", git = "https://github.com/KoalaBotUK/testcord"}
 tox = "*"
 mongomock = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e2655f99580072596df42fc6f0bb7b10bb67078cdbf8cbf4acb54070784c1298"
+            "sha256": "d6e87e11359344297e48ca18f4cb5dc31566160641c1dad7e5985a74b269e9eb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -201,13 +201,6 @@
             ],
             "version": "==0.3.4"
         },
-        "ffmpeg-python": {
-            "hashes": [
-                "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127",
-                "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5"
-            ],
-            "version": "==0.2.0"
-        },
         "filelock": {
             "hashes": [
                 "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85",
@@ -281,13 +274,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.3.0"
         },
-        "future": {
-            "hashes": [
-                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.18.2"
-        },
         "idna": {
             "hashes": [
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
@@ -295,18 +281,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.3"
-        },
-        "imageio-ffmpeg": {
-            "hashes": [
-                "sha256:27b48c32becae1658aa81c3a6b922538e4099edf5fbcbdb4ff5dbc84b8ffd3d3",
-                "sha256:6514f1380daf42815bc8c83aad63f33e0b8b47133421ddafe7b410cd8dfbbea5",
-                "sha256:6aba52ddf0a64442ffcb8d30ac6afb668186acec99ecbc7ae5bd171c4f500bbc",
-                "sha256:7a08838f97f363e37ca41821b864fd3fdc99ab1fe2421040c78eb5f56a9e723e",
-                "sha256:8e724d12dfe83e2a6eb39619e820243ca96c81c47c2648e66e05f7ee24e14312",
-                "sha256:fc60686ef03c2d0f842901b206223c30051a6a120384458761390104470846fd"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==0.4.7"
         },
         "iniconfig": {
             "hashes": [
@@ -403,32 +377,6 @@
             ],
             "version": "==0.4.3"
         },
-        "numpy": {
-            "hashes": [
-                "sha256:07a8c89a04997625236c5ecb7afe35a02af3896c8aa01890a849913a2309c676",
-                "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4",
-                "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce",
-                "sha256:2c10a93606e0b4b95c9b04b77dc349b398fdfbda382d2a39ba5a822f669a0123",
-                "sha256:3ca688e1b9b95d80250bca34b11a05e389b1420d00e87a0d12dc45f131f704a1",
-                "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e",
-                "sha256:568dfd16224abddafb1cbcce2ff14f522abe037268514dd7e42c6776a1c3f8e5",
-                "sha256:5bfb1bb598e8229c2d5d48db1860bcf4311337864ea3efdbe1171fb0c5da515d",
-                "sha256:639b54cdf6aa4f82fe37ebf70401bbb74b8508fddcf4797f9fe59615b8c5813a",
-                "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab",
-                "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75",
-                "sha256:97098b95aa4e418529099c26558eeb8486e66bd1e53a6b606d684d0c3616b168",
-                "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4",
-                "sha256:c34ea7e9d13a70bf2ab64a2532fe149a9aced424cd05a2c4ba662fd989e3e45f",
-                "sha256:dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18",
-                "sha256:e7927a589df200c5e23c57970bafbd0cd322459aa7b1ff73b7c2e84d6e3eae62",
-                "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe",
-                "sha256:f950f8845b480cffe522913d35567e29dd381b0dc7e4ce6a4a9f9156417d2430",
-                "sha256:fade0d4f4d292b6f39951b6836d7a3c7ef5b2347f3c420cd9820a1d90d794802",
-                "sha256:fdf3c08bce27132395d3c3ba1503cac12e17282358cb4bddc25cc46b0aca07aa"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.22.3"
-        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -514,14 +462,7 @@
         },
         "py-cord": {
             "git": "https://github.com/Pycord-Development/pycord",
-            "ref": "8f64303d20a02be052aabe212ef1b38ee2aa311c"
-        },
-        "pycord": {
-            "hashes": [
-                "sha256:de535f91abb49de90e9b318f00edfa38de688d180d1caa4b0e3812c64d36e3c3"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==0.1.1"
+            "ref": "9b3618a2ea10f591f1865614a0d6d10a18f9b94d"
         },
         "pygments": {
             "hashes": [
@@ -636,15 +577,6 @@
             "index": "pypi",
             "version": "==7.1.1"
         },
-        "pytest-asyncio": {
-            "hashes": [
-                "sha256:16cf40bdf2b4fb7fc8e4b82bd05ce3fbcd454cbf7b92afc445fe299dabb88213",
-                "sha256:7659bdb0a9eb9c6e3ef992eef11a2b3e69697800ad02fb06374a210d85b29f91",
-                "sha256:8fafa6c52161addfd41ee7ab35f11836c5a16ec208f93ee388f752bea3493a84"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.18.3"
-        },
         "python-dotenv": {
             "hashes": [
                 "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f",
@@ -690,14 +622,6 @@
             ],
             "index": "pypi",
             "version": "==21.5.0"
-        },
-        "testcord": {
-            "git": "https://github.com/KoalaBotUK/testcord",
-            "hashes": [
-                "sha256:0a4715d6268e10496f293f0cc3b16592a104ff6afe7dca9b31984bce8f77e7a5",
-                "sha256:a05ca6c8e1cd3a5dc4c57ab9805a05a26662f0e93fe313a3e5d90b9852f0fae4"
-            ],
-            "ref": "a6fa99559a888994060ad651af422437c2ad21de"
         },
         "toml": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Building an image locally:
 ### Running locally
 
 1. Install Python 3.10+ - https://python.org/downloads/
-2. Create a virtual environment with `python -m venv .venv` and activate it with `source .venv/bin/activate` (Linux) or `.venv\Scripts\activate.bat` (Windows)
-3. Install dependencies with `pip install -r requirements.txt`
-4. Start bot with `python main.py`
+2. Install Pipenv (our dependency manager) with `pip install pipenv`
+3. Install dependencies with `pipenv install --deploy --dev`
+4. Start the bot with `pipenv run bot`
 
 ### Updating MongoDB migrations
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,21 +38,13 @@ deprecated==1.2.13; python_version >= '2.7' and python_version not in '3.0, 3.1,
 
 distlib==0.3.4
 
-ffmpeg-python==0.2.0
-
 filelock==3.6.0; python_version >= '3.7'
 
 frozenlist==1.3.0; python_version >= '3.7'
 
-future==0.18.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
-
-git+https://github.com/KoalaBotUK/testcord@a6fa99559a888994060ad651af422437c2ad21de#egg=testcord
-
-git+https://github.com/Pycord-Development/pycord@8f64303d20a02be052aabe212ef1b38ee2aa311c#egg=py-cord
+git+https://github.com/Pycord-Development/pycord@9b3618a2ea10f591f1865614a0d6d10a18f9b94d#egg=py-cord
 
 idna==3.3; python_version >= '3.5'
-
-imageio-ffmpeg==0.4.7; python_version >= '3.5'
 
 iniconfig==1.1.1
 
@@ -63,8 +55,6 @@ mongomock==4.0.0
 multidict==6.0.2; python_version >= '3.7'
 
 mypy-extensions==0.4.3
-
-numpy==1.22.3; python_version >= '3.8'
 
 packaging==21.3; python_version >= '3.6'
 
@@ -78,15 +68,11 @@ pluggy==1.0.0; python_version >= '3.6'
 
 py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 
-pycord==0.1.1; python_version >= '3.5'
-
 pygments==2.11.2; python_version >= '3.5'
 
 pymongo==4.1.1; python_full_version >= '3.6.2'
 
 pyparsing==3.0.8; python_full_version >= '3.6.8'
-
-pytest-asyncio==0.18.3; python_version >= '3.7'
 
 pytest==7.1.1
 


### PR DESCRIPTION
Remove Testcord to avoid it from being used accidentally. The patched version in `vendor/` should be used instead.